### PR TITLE
feature: check address reuse

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "devDependencies": {
     "@types/node": "^18.15.11",
     "typescript": "^5.0.4"
+  },
+  "dependencies": {
+    "bitcoinjs-lib": "^6.1.0"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,1 @@
-export { hello } from './lib/privateTx';
+export { checkAddressReuse } from './lib/address-reuse';

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.hello = void 0;
-var privateTx_1 = require("./lib/privateTx");
-Object.defineProperty(exports, "hello", { enumerable: true, get: function () { return privateTx_1.hello; } });
+exports.checkAddressReuse = void 0;
+var address_reuse_1 = require("./lib/address-reuse");
+Object.defineProperty(exports, "checkAddressReuse", { enumerable: true, get: function () { return address_reuse_1.checkAddressReuse; } });

--- a/src/lib/address-reuse.d.ts
+++ b/src/lib/address-reuse.d.ts
@@ -1,0 +1,9 @@
+export interface AddressReuseResponse {
+    status: boolean;
+    data: reusedInsAndOuts[];
+}
+export interface reusedInsAndOuts {
+    vin: number;
+    vout: number;
+}
+export declare const checkAddressReuse: (psbtBase64: string) => AddressReuseResponse;

--- a/src/lib/address-reuse.js
+++ b/src/lib/address-reuse.js
@@ -1,0 +1,51 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.checkAddressReuse = void 0;
+const bitcoin = require("bitcoinjs-lib");
+const buffer_1 = require("buffer");
+const checkAddressReuse = (psbtBase64) => {
+    // Decode the base64-encoded PSBT
+    const psbtBuffer = buffer_1.Buffer.from(psbtBase64, 'base64');
+    const psbt = bitcoin.Psbt.fromBuffer(psbtBuffer);
+    // Get the transactions inputs addresses
+    const inputs = psbt.data.inputs;
+    let inputAddresses = [];
+    for (let i = 0; i < inputs.length; i++) {
+        // vout is the UTXO index of the input
+        let vout = psbt.txInputs[i].index;
+        //  Get the hex representation of the serialized input transaction
+        let serializedTx = inputs[i].nonWitnessUtxo?.toString('hex');
+        // Decode the serialied transaction
+        let tx = serializedTx ? bitcoin.Transaction.fromHex(serializedTx) : undefined;
+        // convert the scriptpubkey of the input UTXO to an address
+        let address = tx ? bitcoin.address.fromOutputScript(tx.outs[vout].script) : "";
+        inputAddresses.push(address);
+    }
+    // Get the transactions outputs addresses
+    const outputs = psbt.txOutputs;
+    let outputAddresses = [];
+    for (let i = 0; i < outputs.length; i++) {
+        // convert the scriptpubkey of the output to an address
+        let address = bitcoin.address.fromOutputScript(outputs[i].script);
+        outputAddresses.push(address);
+    }
+    let response = {
+        status: false,
+        data: []
+    };
+    // check for address reuse
+    for (let i = 0; i < inputAddresses.length; i++) {
+        for (let j = 0; j < outputAddresses.length; j++) {
+            if (inputAddresses[i] == outputAddresses[j]) {
+                response.status = true;
+                let reuse = {
+                    vin: i,
+                    vout: j
+                };
+                response.data.push(reuse);
+            }
+        }
+    }
+    return response;
+};
+exports.checkAddressReuse = checkAddressReuse;

--- a/src/lib/privateTx.d.ts
+++ b/src/lib/privateTx.d.ts
@@ -1,1 +1,0 @@
-export declare const hello: (val: string) => void;

--- a/src/lib/privateTx.js
+++ b/src/lib/privateTx.js
@@ -1,7 +1,0 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.hello = void 0;
-const hello = (val) => {
-    console.log(val);
-};
-exports.hello = hello;

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -1,3 +1,3 @@
-export {hello} from './lib/privateTx'
+export {checkAddressReuse} from './lib/address-reuse'
 
  

--- a/ts_src/lib/address-reuse.ts
+++ b/ts_src/lib/address-reuse.ts
@@ -1,0 +1,75 @@
+import * as bitcoin from 'bitcoinjs-lib';
+import { PsbtInput } from 'bip174/src/lib/interfaces';
+import { Buffer } from 'buffer';
+
+
+// Define Check Address Reuse response
+export interface AddressReuseResponse {
+  status:boolean,
+  data:reusedInsAndOuts[]
+}
+export interface reusedInsAndOuts {
+  vin:number,
+  vout:number
+}
+
+
+export const checkAddressReuse  = (psbtBase64:string):AddressReuseResponse =>{
+  // Decode the base64-encoded PSBT
+  const psbtBuffer: Buffer = Buffer.from(psbtBase64, 'base64');
+  const psbt: bitcoin.Psbt = bitcoin.Psbt.fromBuffer(psbtBuffer);
+
+  // Get the transactions inputs addresses
+  const inputs:PsbtInput[] = psbt.data.inputs;
+  let inputAddresses = [];
+
+  for(let i:number = 0;i< inputs.length ; i++){
+    
+    // vout is the UTXO index of the input
+    let vout:number = psbt.txInputs[i].index; 
+
+    //  Get the hex representation of the serialized input transaction
+    let serializedTx = inputs[i].nonWitnessUtxo?.toString('hex');
+
+    // Decode the serialied transaction
+    let tx = serializedTx ? bitcoin.Transaction.fromHex(serializedTx) : undefined ;
+
+    // convert the scriptpubkey of the input UTXO to an address
+    let address:string = tx? bitcoin.address.fromOutputScript(tx.outs[vout].script) : "";
+    inputAddresses.push(address);
+  }
+
+  // Get the transactions outputs addresses
+  const outputs = psbt.txOutputs;
+  let outputAddresses = [];
+
+  for(let i = 0;i< outputs.length;i++){
+    // convert the scriptpubkey of the output to an address
+    let address = bitcoin.address.fromOutputScript(outputs[i].script);
+    outputAddresses.push(address)
+  }
+
+  let response:AddressReuseResponse = {
+    status:false,
+    data:[]
+  }
+
+  // check for address reuse
+  for (let i:number = 0; i < inputAddresses.length;i++){
+
+    for (let j = 0;j < outputAddresses.length;j++){
+
+      if (inputAddresses[i] == outputAddresses[j]) {
+
+        response.status = true;
+        let reuse:reusedInsAndOuts = {
+          vin:i,
+          vout:j
+        }
+
+        response.data.push(reuse)
+      }
+    }
+  }
+  return response;
+}

--- a/ts_src/lib/privateTx.ts
+++ b/ts_src/lib/privateTx.ts
@@ -1,3 +1,0 @@
-export const hello  = (val:string)=>{
-  console.log(val)
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,9 +16,9 @@
   },
   "include": [
     "ts_src/**/*.ts"
-],
-"exclude": [
-    "**/*.spec.ts",
-    "node_modules/**/*"
-]
+  ],
+  "exclude": [
+      "**/*.spec.ts",
+      "node_modules/**/*"
+  ]
 }


### PR DESCRIPTION
| Private Tx feature |
|--------|
| check address reuse | 

`checkAddressReuse` input is a base 64 PSBT. it determines whether there is address reuse in the transaction.

`checkAddressReuse` checks all the input `scriptPubkey` against the outputs `scriptPubkey`.
It generates the status true if there is reuse, with the vin and vout where it the reuse occur, else status is false.