### PR TITLE
feature: common inputs and peeling

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,2 +1,3 @@
 export { checkAddressReuse } from './lib/address-reuse';
 export { commonInputs } from './lib/common-input';
+export { peelingTransaction } from './lib/peeling';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,2 @@
 export { checkAddressReuse } from './lib/address-reuse';
+export { commonInputs } from './lib/common-input';

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.checkAddressReuse = void 0;
+exports.commonInputs = exports.checkAddressReuse = void 0;
 var address_reuse_1 = require("./lib/address-reuse");
 Object.defineProperty(exports, "checkAddressReuse", { enumerable: true, get: function () { return address_reuse_1.checkAddressReuse; } });
+var common_input_1 = require("./lib/common-input");
+Object.defineProperty(exports, "commonInputs", { enumerable: true, get: function () { return common_input_1.commonInputs; } });

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.commonInputs = exports.checkAddressReuse = void 0;
+exports.peelingTransaction = exports.commonInputs = exports.checkAddressReuse = void 0;
 var address_reuse_1 = require("./lib/address-reuse");
 Object.defineProperty(exports, "checkAddressReuse", { enumerable: true, get: function () { return address_reuse_1.checkAddressReuse; } });
 var common_input_1 = require("./lib/common-input");
 Object.defineProperty(exports, "commonInputs", { enumerable: true, get: function () { return common_input_1.commonInputs; } });
+var peeling_1 = require("./lib/peeling");
+Object.defineProperty(exports, "peelingTransaction", { enumerable: true, get: function () { return peeling_1.peelingTransaction; } });

--- a/src/lib/common-input.d.ts
+++ b/src/lib/common-input.d.ts
@@ -1,0 +1,1 @@
+export declare const commonInputs: (psbtBase64: string) => boolean;

--- a/src/lib/common-input.js
+++ b/src/lib/common-input.js
@@ -1,0 +1,55 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.commonInputs = void 0;
+const bitcoin = require("bitcoinjs-lib");
+const buffer_1 = require("buffer");
+function numberSort(a, b) {
+    return a - b;
+}
+const commonInputs = (psbtBase64) => {
+    // Decode the base64-encoded PSBT
+    const psbtBuffer = buffer_1.Buffer.from(psbtBase64, 'base64');
+    const psbt = bitcoin.Psbt.fromBuffer(psbtBuffer);
+    // Get the transactions inputs
+    const inputs = psbt.data.inputs;
+    // Get the transactions outputs 
+    const outputs = psbt.txOutputs;
+    //  Edge cases
+    if (outputs.length === 1 || inputs.length === 1) {
+        return true;
+    }
+    const inputAmounts = [];
+    const outputAmounts = [];
+    for (let i = 0; i < inputs.length; i++) {
+        // vout is the UTXO index of the input
+        let vout = psbt.txInputs[i].index;
+        //  Get the hex representation of the serialized input transaction
+        let serializedTx = inputs[i].nonWitnessUtxo?.toString('hex');
+        // Decode the serialied transaction
+        let tx = serializedTx ? bitcoin.Transaction.fromHex(serializedTx) : undefined;
+        if (tx) {
+            inputAmounts.push(tx.outs[vout].value);
+        }
+    }
+    for (let i = 0; i < outputs.length; i++) {
+        outputAmounts.push(outputs[i].value);
+    }
+    outputAmounts.sort(numberSort);
+    inputAmounts.sort(numberSort);
+    let result = true;
+    for (let i = 0; i < outputAmounts.length; i++) {
+        for (let j = 0; j < inputAmounts.length; j++) {
+            // check if the output amount is less than or equal to an input 
+            // If yes then the input is enough to spend the output
+            // other inputs might not be from same wallet
+            if (outputAmounts[i] <= inputAmounts[j]) {
+                result = false;
+            }
+            else {
+                result = true;
+            }
+        }
+    }
+    return result;
+};
+exports.commonInputs = commonInputs;

--- a/src/lib/peeling.d.ts
+++ b/src/lib/peeling.d.ts
@@ -1,0 +1,5 @@
+export interface peelingTransactionResponse {
+    status: boolean;
+    index: number;
+}
+export declare const peelingTransaction: (psbtBase64: string) => peelingTransactionResponse;

--- a/src/lib/peeling.js
+++ b/src/lib/peeling.js
@@ -1,0 +1,45 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.peelingTransaction = void 0;
+const bitcoin = require("bitcoinjs-lib");
+const buffer_1 = require("buffer");
+function numberSort(a, b) {
+    return a - b;
+}
+const peelingTransaction = (psbtBase64) => {
+    // Decode the base64-encoded PSBT
+    const psbtBuffer = buffer_1.Buffer.from(psbtBase64, 'base64');
+    const psbt = bitcoin.Psbt.fromBuffer(psbtBuffer);
+    // Get the transactions outputs 
+    const outputs = psbt.txOutputs;
+    const outputAmounts = [];
+    for (let i = 0; i < outputs.length; i++) {
+        outputAmounts.push(outputs[i].value);
+    }
+    let response = {
+        status: false,
+        index: -1
+    };
+    // Edge case
+    if (outputAmounts.length === 1) {
+        return response;
+    }
+    outputAmounts.sort(numberSort);
+    let largestAmount = outputAmounts[outputAmounts.length - 1];
+    let secondLargestAmount = outputAmounts[outputAmounts.length - 2];
+    let difference = largestAmount - secondLargestAmount;
+    let halfOfSecondLargestAmount = secondLargestAmount / 2;
+    if (difference < halfOfSecondLargestAmount) {
+        return response;
+    }
+    let vout = -1;
+    for (let i = 0; i < outputs.length; i++) {
+        if (outputs[i].value == largestAmount) {
+            vout = i;
+        }
+    }
+    response.status = true;
+    response.index = vout;
+    return response;
+};
+exports.peelingTransaction = peelingTransaction;

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -1,3 +1,4 @@
-export {checkAddressReuse} from './lib/address-reuse'
+export { checkAddressReuse } from './lib/address-reuse';
+export { commonInputs } from './lib/common-input'
 
  

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -1,4 +1,5 @@
 export { checkAddressReuse } from './lib/address-reuse';
 export { commonInputs } from './lib/common-input'
+export { peelingTransaction } from './lib/peeling'
 
  

--- a/ts_src/lib/address-reuse.ts
+++ b/ts_src/lib/address-reuse.ts
@@ -5,12 +5,12 @@ import { Buffer } from 'buffer';
 
 // Define Check Address Reuse response
 export interface AddressReuseResponse {
-  status:boolean,
-  data:reusedInsAndOuts[]
+  status: boolean,
+  data: reusedInsAndOuts[]
 }
 export interface reusedInsAndOuts {
-  vin:number,
-  vout:number
+  vin: number,
+  vout: number
 }
 
 
@@ -20,13 +20,13 @@ export const checkAddressReuse  = (psbtBase64:string):AddressReuseResponse =>{
   const psbt: bitcoin.Psbt = bitcoin.Psbt.fromBuffer(psbtBuffer);
 
   // Get the transactions inputs addresses
-  const inputs:PsbtInput[] = psbt.data.inputs;
+  const inputs: PsbtInput[] = psbt.data.inputs;
   let inputAddresses = [];
 
-  for(let i:number = 0;i< inputs.length ; i++){
+  for(let i = 0; i< inputs.length; i++){
     
     // vout is the UTXO index of the input
-    let vout:number = psbt.txInputs[i].index; 
+    let vout: number = psbt.txInputs[i].index; 
 
     //  Get the hex representation of the serialized input transaction
     let serializedTx = inputs[i].nonWitnessUtxo?.toString('hex');
@@ -35,7 +35,7 @@ export const checkAddressReuse  = (psbtBase64:string):AddressReuseResponse =>{
     let tx = serializedTx ? bitcoin.Transaction.fromHex(serializedTx) : undefined ;
 
     // convert the scriptpubkey of the input UTXO to an address
-    let address:string = tx? bitcoin.address.fromOutputScript(tx.outs[vout].script) : "";
+    let address: string = tx? bitcoin.address.fromOutputScript(tx.outs[vout].script) : "";
     inputAddresses.push(address);
   }
 
@@ -43,26 +43,26 @@ export const checkAddressReuse  = (psbtBase64:string):AddressReuseResponse =>{
   const outputs = psbt.txOutputs;
   let outputAddresses = [];
 
-  for(let i = 0;i< outputs.length;i++){
+  for(let i = 0; i< outputs.length; i++){
     // convert the scriptpubkey of the output to an address
     let address = bitcoin.address.fromOutputScript(outputs[i].script);
     outputAddresses.push(address)
   }
 
   let response:AddressReuseResponse = {
-    status:false,
-    data:[]
+    status: false,
+    data: []
   }
 
   // check for address reuse
-  for (let i:number = 0; i < inputAddresses.length;i++){
+  for (let i = 0; i< inputAddresses.length; i++){
 
-    for (let j = 0;j < outputAddresses.length;j++){
+    for (let j = 0; j< outputAddresses.length; j++){
 
       if (inputAddresses[i] == outputAddresses[j]) {
 
         response.status = true;
-        let reuse:reusedInsAndOuts = {
+        let reuse: reusedInsAndOuts = {
           vin:i,
           vout:j
         }

--- a/ts_src/lib/common-input.ts
+++ b/ts_src/lib/common-input.ts
@@ -1,0 +1,71 @@
+import * as bitcoin from 'bitcoinjs-lib';
+import { PsbtInput } from 'bip174/src/lib/interfaces';
+import { Buffer } from 'buffer';
+
+function numberSort(a:number, b:number) {
+  return a - b;
+}
+
+export const commonInputs = (psbtBase64:string):boolean =>{
+
+  // Decode the base64-encoded PSBT
+  const psbtBuffer: Buffer = Buffer.from(psbtBase64, 'base64');
+  const psbt: bitcoin.Psbt = bitcoin.Psbt.fromBuffer(psbtBuffer);
+
+
+  // Get the transactions inputs
+  const inputs: PsbtInput[] = psbt.data.inputs;
+
+  // Get the transactions outputs 
+  const outputs:bitcoin.PsbtTxOutput[] = psbt.txOutputs
+
+  //  Edge cases
+  if (outputs.length === 1 || inputs.length === 1) {
+    return true;
+  }
+
+  const inputAmounts: number[] = [];
+  const outputAmounts: number[] = [];
+
+  for(let i = 0; i< inputs.length; i++){
+
+    // vout is the UTXO index of the input
+    let vout: number = psbt.txInputs[i].index; 
+
+    //  Get the hex representation of the serialized input transaction
+    let serializedTx = inputs[i].nonWitnessUtxo?.toString('hex');
+
+    // Decode the serialied transaction
+    let tx = serializedTx ? bitcoin.Transaction.fromHex(serializedTx) : undefined ;
+    if (tx) {
+      inputAmounts.push(tx.outs[vout].value)
+    }
+  }
+
+  for(let i = 0; i< outputs.length; i++) {
+    outputAmounts.push(outputs[i].value);
+  }
+
+  outputAmounts.sort(numberSort);
+  inputAmounts.sort(numberSort);
+
+  let result = true;
+  for(let i = 0; i< outputAmounts.length; i++) {
+
+    for(let j = 0; j< inputAmounts.length; j++){
+
+      // check if the output amount is less than or equal to an input 
+      // If yes then the input is enough to spend the output
+      // other inputs might not be from same wallet
+      if ( outputAmounts[i] <= inputAmounts[j]) {
+
+        result = false;
+      } 
+      else  { result = true; }
+
+    }
+  }
+
+  return result
+
+}

--- a/ts_src/lib/peeling.ts
+++ b/ts_src/lib/peeling.ts
@@ -1,0 +1,66 @@
+import * as bitcoin from 'bitcoinjs-lib';
+import { Buffer } from 'buffer';
+
+
+export interface peelingTransactionResponse {
+  status: boolean
+  index: number
+}
+function numberSort(a:number, b:number) {
+  return a - b;
+}
+
+export const peelingTransaction = (psbtBase64:string):peelingTransactionResponse =>{
+
+  // Decode the base64-encoded PSBT
+  const psbtBuffer: Buffer = Buffer.from(psbtBase64, 'base64');
+  const psbt: bitcoin.Psbt = bitcoin.Psbt.fromBuffer(psbtBuffer);
+
+
+  // Get the transactions outputs 
+  const outputs:bitcoin.PsbtTxOutput[] = psbt.txOutputs
+
+
+  const outputAmounts: number[] = [];
+
+
+  for(let i = 0; i< outputs.length; i++) {
+    outputAmounts.push(outputs[i].value);
+  }
+
+  let response: peelingTransactionResponse = {
+    status:false,
+    index: -1
+  }
+  // Edge case
+  if (outputAmounts.length === 1 ){
+    return response;
+  }
+
+  outputAmounts.sort(numberSort);
+
+  let largestAmount = outputAmounts[outputAmounts.length -1];
+  let secondLargestAmount = outputAmounts[outputAmounts.length -2];
+
+  let difference = largestAmount - secondLargestAmount;
+
+  let halfOfSecondLargestAmount = secondLargestAmount / 2;
+
+
+  if (difference < halfOfSecondLargestAmount) {
+    return response;
+  } 
+
+  let vout:number = -1;
+  for(let i = 0; i< outputs.length; i++){
+
+    if(outputs[i].value == largestAmount){
+      vout = i
+    }
+  }
+
+  response.status = true;
+  response.index = vout;
+  return response;
+
+}


### PR DESCRIPTION
| Private Tx feature |
|--------|
|Common Inputs|
|Peeling transaction| 

`commonInputs` takes a base64 psbt string as an input, returns true if the inputs are likely to be from the same wallet, or false if otherwise

`peelingTransaction`  also takes a base64 psbt string as input, and returns true if the psbt is a peeling transaction with the index of the change output. whereas returns false if it's not a peeling transaction.