### PR TITLE
feature: detect legacy lightning closing channel

### DIFF
--- a/src/common/convert-psbt-to-hex.d.ts
+++ b/src/common/convert-psbt-to-hex.d.ts
@@ -1,0 +1,6 @@
+export interface ConvertPsbtToHexResponse {
+    status: boolean;
+    error?: string;
+    transactionHex?: string;
+}
+export declare const convertPsbtToHex: (psbtBase64: string) => ConvertPsbtToHexResponse;

--- a/src/common/convert-psbt-to-hex.js
+++ b/src/common/convert-psbt-to-hex.js
@@ -1,0 +1,35 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.convertPsbtToHex = void 0;
+const decode_psbt_1 = require("../common/decode_psbt");
+// Define the function to convert a base64-encoded PSBT to transaction hex
+const convertPsbtToHex = (psbtBase64) => {
+    try {
+        // Decode the base64-encoded PSBT
+        const decodedPsbt = (0, decode_psbt_1.decodePsbt)(psbtBase64);
+        // Check for errors in decoding the PSBT
+        if (!decodedPsbt.status || !decodedPsbt.data) {
+            return {
+                status: false,
+                error: decodedPsbt.error,
+            };
+        }
+        // Get the PSBT object from the decoded PSBT data
+        const psbt = decodedPsbt.data;
+        // Extract the transaction hex from the PSBT object
+        const transactionHex = psbt.extractTransaction(true).toHex();
+        // Return the transaction hex in the response
+        return {
+            status: true,
+            transactionHex: transactionHex
+        };
+    }
+    catch (err) {
+        // Return error if any exception occurs
+        return {
+            status: false,
+            error: JSON.stringify(err)
+        };
+    }
+};
+exports.convertPsbtToHex = convertPsbtToHex;

--- a/src/common/decode-transaction.d.ts
+++ b/src/common/decode-transaction.d.ts
@@ -1,0 +1,7 @@
+import * as bitcoin from 'bitcoinjs-lib';
+export interface DecodeRawTransactionResponse {
+    status: boolean;
+    error?: any;
+    transaction?: bitcoin.Transaction;
+}
+export declare const decodeRawTransaction: (rawTransaction: string) => DecodeRawTransactionResponse;

--- a/src/common/decode-transaction.js
+++ b/src/common/decode-transaction.js
@@ -1,0 +1,24 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.decodeRawTransaction = void 0;
+const bitcoin = require("bitcoinjs-lib");
+// Define the decodeRawTransaction which decodes a raw transaction hex to a standard Transaction
+const decodeRawTransaction = (rawTransaction) => {
+    try {
+        // Decode the raw transaction
+        const tx = bitcoin.Transaction.fromHex(rawTransaction);
+        // Return the decoded transaction object
+        return {
+            status: true,
+            transaction: tx
+        };
+    }
+    catch (err) {
+        // If an error occurred, return an error response with the error message
+        return {
+            status: false,
+            error: err
+        };
+    }
+};
+exports.decodeRawTransaction = decodeRawTransaction;

--- a/src/common/get-inputs.d.ts
+++ b/src/common/get-inputs.d.ts
@@ -1,0 +1,14 @@
+import * as bitcoin from 'bitcoinjs-lib';
+export interface Input {
+    txid: string;
+    n: number;
+    script: string;
+    sequence: number;
+    witness: string[];
+}
+export interface GetTransactionInputResponse {
+    status: boolean;
+    data?: Input[];
+    error?: string;
+}
+export declare const getTransactionInputs: (transaction: bitcoin.Transaction) => GetTransactionInputResponse;

--- a/src/common/get-inputs.js
+++ b/src/common/get-inputs.js
@@ -1,0 +1,33 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getTransactionInputs = void 0;
+const bitcoin = require("bitcoinjs-lib");
+// Define a function to get the inputs of a transaction
+const getTransactionInputs = (transaction) => {
+    try {
+        const inputs = [];
+        transaction.ins.map((input) => {
+            // Parse the input and add it to the array of inputs
+            inputs.push({
+                txid: input.hash.reverse().toString('hex'),
+                n: input.index,
+                script: bitcoin.script.toASM(input.script),
+                sequence: input.sequence,
+                witness: input.witness.map((witnessBuffer) => Buffer.from(witnessBuffer).toString('hex')) // Convert the witnesses to hexadecimal strings
+            });
+        });
+        // Return the inputs as a successful response
+        return {
+            status: true,
+            data: inputs
+        };
+    }
+    catch (error) {
+        // Return an error response if there is an exception
+        return {
+            status: false,
+            error: JSON.stringify(error),
+        };
+    }
+};
+exports.getTransactionInputs = getTransactionInputs;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,3 +2,4 @@ export { checkAddressReuse } from './lib/address-reuse';
 export { commonInputs } from './lib/common-input';
 export { peelingTransaction } from './lib/peeling';
 export { detectChange } from './lib/detect-change';
+export { detectLightningChannelClose, detectLightningChannelClosePsbt } from './lib/detect-lightning-close';

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.detectChange = exports.peelingTransaction = exports.commonInputs = exports.checkAddressReuse = void 0;
+exports.detectLightningChannelClosePsbt = exports.detectLightningChannelClose = exports.detectChange = exports.peelingTransaction = exports.commonInputs = exports.checkAddressReuse = void 0;
 var address_reuse_1 = require("./lib/address-reuse");
 Object.defineProperty(exports, "checkAddressReuse", { enumerable: true, get: function () { return address_reuse_1.checkAddressReuse; } });
 var common_input_1 = require("./lib/common-input");
@@ -9,3 +9,6 @@ var peeling_1 = require("./lib/peeling");
 Object.defineProperty(exports, "peelingTransaction", { enumerable: true, get: function () { return peeling_1.peelingTransaction; } });
 var detect_change_1 = require("./lib/detect-change");
 Object.defineProperty(exports, "detectChange", { enumerable: true, get: function () { return detect_change_1.detectChange; } });
+var detect_lightning_close_1 = require("./lib/detect-lightning-close");
+Object.defineProperty(exports, "detectLightningChannelClose", { enumerable: true, get: function () { return detect_lightning_close_1.detectLightningChannelClose; } });
+Object.defineProperty(exports, "detectLightningChannelClosePsbt", { enumerable: true, get: function () { return detect_lightning_close_1.detectLightningChannelClosePsbt; } });

--- a/src/lib/detect-lightning-close.d.ts
+++ b/src/lib/detect-lightning-close.d.ts
@@ -1,0 +1,7 @@
+export interface DetectLightningChannelCloseResponse {
+    status: boolean;
+    inputs?: number[];
+    error?: string;
+}
+export declare const detectLightningChannelClose: (transactionHex: string) => DetectLightningChannelCloseResponse;
+export declare const detectLightningChannelClosePsbt: (psbtBase64: string) => DetectLightningChannelCloseResponse;

--- a/src/lib/detect-lightning-close.js
+++ b/src/lib/detect-lightning-close.js
@@ -1,0 +1,76 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.detectLightningChannelClosePsbt = exports.detectLightningChannelClose = void 0;
+const convert_psbt_to_hex_1 = require("../common/convert-psbt-to-hex");
+const get_inputs_1 = require("../common/get-inputs");
+const decode_transaction_1 = require("../common/decode-transaction");
+const script_1 = require("bitcoinjs-lib/src/script");
+const OP_0 = "OP_0";
+// Function to detect a 2-of-2 multisig input in legacy format
+const detectLegacy2Of2Multisig = (scriptSig) => {
+    const script = scriptSig.split(' ');
+    // Check length and OP_0
+    if (script.length !== 3 || script[0] !== OP_0) {
+        return false;
+    }
+    // Check signature format
+    try {
+        const isValid1stSig = (0, script_1.isCanonicalScriptSignature)(Buffer.from(script[1], 'hex'));
+        const isValid2ndSig = (0, script_1.isCanonicalScriptSignature)(Buffer.from(script[2], 'hex'));
+        return isValid1stSig && isValid2ndSig;
+    }
+    catch (error) {
+        return false;
+    }
+};
+// Function to detect a 2-of-2 multisig input in witness format
+const detect2Of2Multisig = (scriptSig) => {
+    // Not implemented yet
+    return scriptSig.length < 0;
+};
+// Function to detect lightning channel close inputs
+const detectLightningChannelClose = (transactionHex) => {
+    // Decode the transaction
+    const transaction = (0, decode_transaction_1.decodeRawTransaction)(transactionHex);
+    if (!transaction.status) {
+        return { status: false, error: transaction.error };
+    }
+    // Get the transaction inputs
+    const inputs = (0, get_inputs_1.getTransactionInputs)(transaction.transaction);
+    if (!inputs.status) {
+        return { status: false, error: inputs.error };
+    }
+    // Find the indices of inputs that are 2-of-2 multisig
+    const multisigInputIndices = [];
+    for (let i = 0; i < inputs.data.length; i++) {
+        // Check for 2-of-2 multisig input in legacy format
+        if (inputs.data[i].script.length > 0) {
+            const isLegacy2Of2Multisig = detectLegacy2Of2Multisig(inputs.data[i].script);
+            if (isLegacy2Of2Multisig) {
+                multisigInputIndices.push(i);
+            }
+        }
+        // Check for 2-of-2 multisig input in witness format
+        const isWitness2Of2Multisig = detect2Of2Multisig(inputs.data[i].witness);
+        if (isWitness2Of2Multisig) {
+            multisigInputIndices.push(i);
+        }
+    }
+    // Return the result
+    return {
+        status: multisigInputIndices.length > 0,
+        inputs: multisigInputIndices,
+    };
+};
+exports.detectLightningChannelClose = detectLightningChannelClose;
+// Function to detect lightning channel close inputs in PSBT format
+const detectLightningChannelClosePsbt = (psbtBase64) => {
+    // Convert PSBT to transaction hex
+    const transactionHex = (0, convert_psbt_to_hex_1.convertPsbtToHex)(psbtBase64);
+    if (transactionHex.status === false) {
+        return { status: false, error: transactionHex.error };
+    }
+    // Detect lightning channel close inputs
+    return (0, exports.detectLightningChannelClose)(transactionHex.transactionHex);
+};
+exports.detectLightningChannelClosePsbt = detectLightningChannelClosePsbt;

--- a/ts_src/common/convert-psbt-to-hex.ts
+++ b/ts_src/common/convert-psbt-to-hex.ts
@@ -1,0 +1,45 @@
+import * as bitcoin from 'bitcoinjs-lib';
+import { decodePsbt } from '../common/decode_psbt';
+
+// Define the response interface
+export interface ConvertPsbtToHexResponse {
+  status: boolean,
+  error?: string,
+  transactionHex?: string
+}
+
+// Define the function to convert a base64-encoded PSBT to transaction hex
+export const convertPsbtToHex = (psbtBase64:string):ConvertPsbtToHexResponse =>{
+
+  try {
+    // Decode the base64-encoded PSBT
+    const decodedPsbt = decodePsbt(psbtBase64);
+
+    // Check for errors in decoding the PSBT
+    if (!decodedPsbt.status || !decodedPsbt.data) {
+      return {
+        status: false,
+        error: decodedPsbt.error,
+      };
+    }
+
+    // Get the PSBT object from the decoded PSBT data
+    const psbt: bitcoin.Psbt = decodedPsbt.data!;
+
+    // Extract the transaction hex from the PSBT object
+    const transactionHex = psbt.extractTransaction(true).toHex();
+
+    // Return the transaction hex in the response
+    return {
+      status: true,
+      transactionHex: transactionHex
+    }
+
+  } catch (err) {
+    // Return error if any exception occurs
+    return {
+      status: false,
+      error: JSON.stringify(err)
+    }
+  }
+}

--- a/ts_src/common/decode-transaction.ts
+++ b/ts_src/common/decode-transaction.ts
@@ -1,0 +1,27 @@
+import * as bitcoin from 'bitcoinjs-lib';
+
+// Define the response interface for the decodeRawTransaction function
+export interface DecodeRawTransactionResponse {
+  status: boolean,
+  error?: any,
+  transaction?: bitcoin.Transaction
+}
+
+// Define the decodeRawTransaction which decodes a raw transaction hex to a standard Transaction
+export const decodeRawTransaction = (rawTransaction:string):DecodeRawTransactionResponse =>{
+  try {
+    // Decode the raw transaction
+    const tx = bitcoin.Transaction.fromHex(rawTransaction);
+    // Return the decoded transaction object
+    return {
+      status: true,
+      transaction:tx
+    }
+  }catch (err:any){
+    // If an error occurred, return an error response with the error message
+    return {
+      status:false,
+      error: err
+    }
+  }
+}

--- a/ts_src/common/get-inputs.ts
+++ b/ts_src/common/get-inputs.ts
@@ -1,0 +1,45 @@
+import * as bitcoin from 'bitcoinjs-lib';
+
+// Define the structure of an input
+export interface Input {
+  txid: string,      // Transaction ID
+  n: number,         // Index of the input in the transaction
+  script: string,    // Script
+  sequence: number,  // Sequence number
+  witness: string[]  // Array of witnesses
+}
+
+// Define the structure of the response
+export interface GetTransactionInputResponse {
+  status: boolean,  // Indicates whether the operation was successful or not
+  data?: Input[],   // Array of inputs (optional)
+  error?: string    // Error message (optional)
+}
+
+// Define a function to get the inputs of a transaction
+export const getTransactionInputs = (transaction: bitcoin.Transaction): GetTransactionInputResponse => {
+  try {
+    const inputs: Input[] = [];
+    transaction.ins.map((input) => {
+      // Parse the input and add it to the array of inputs
+      inputs.push({
+        txid: input.hash.reverse().toString('hex'),                  // Convert the transaction ID to a hexadecimal string
+        n: input.index,                                             // Get the index of the input in the transaction
+        script: bitcoin.script.toASM(input.script),                 // Convert the script to human-readable form
+        sequence: input.sequence,                                   // Get the sequence number
+        witness: input.witness.map((witnessBuffer) => Buffer.from(witnessBuffer).toString('hex')) // Convert the witnesses to hexadecimal strings
+      });
+    });
+    // Return the inputs as a successful response
+    return {
+      status: true,
+      data: inputs
+    };
+  } catch (error) {
+    // Return an error response if there is an exception
+    return {
+      status: false,
+      error: JSON.stringify(error),
+    };
+  }
+};

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -2,5 +2,4 @@ export { checkAddressReuse } from './lib/address-reuse';
 export { commonInputs } from './lib/common-input';
 export { peelingTransaction } from './lib/peeling';
 export { detectChange } from './lib/detect-change';
-
- 
+export { detectLightningChannelClose , detectLightningChannelClosePsbt} from './lib/detect-lightning-close'

--- a/ts_src/lib/detect-lightning-close.ts
+++ b/ts_src/lib/detect-lightning-close.ts
@@ -1,0 +1,92 @@
+import { convertPsbtToHex } from '../common/convert-psbt-to-hex';
+import { getTransactionInputs } from '../common/get-inputs';
+import { decodeRawTransaction } from '../common/decode-transaction';
+import { isCanonicalScriptSignature } from 'bitcoinjs-lib/src/script';
+
+export interface DetectLightningChannelCloseResponse {
+  status: boolean,
+  inputs?: number[],
+  error?: string
+}
+
+const OP_0 = "OP_0";
+
+// Function to detect a 2-of-2 multisig input in legacy format
+const detectLegacy2Of2Multisig = (scriptSig: string): boolean => {
+  const script = scriptSig.split(' ');
+
+  // Check length and OP_0
+  if ( script.length !== 3 || script[0] !== OP_0 ) {
+    return false;
+  }
+
+  // Check signature format
+  try {
+    const isValid1stSig = isCanonicalScriptSignature(Buffer.from(script[1], 'hex'));
+    const isValid2ndSig = isCanonicalScriptSignature(Buffer.from(script[2], 'hex'));
+
+    return isValid1stSig && isValid2ndSig;
+
+  } catch (error) {
+    return false;
+  }
+};
+
+// Function to detect a 2-of-2 multisig input in witness format
+const detect2Of2Multisig = (scriptSig:string[]):boolean =>{
+  // Not implemented yet
+  return scriptSig.length < 0 ;
+}
+
+// Function to detect lightning channel close inputs
+export const detectLightningChannelClose = (transactionHex: string): DetectLightningChannelCloseResponse => {
+
+  // Decode the transaction
+  const transaction = decodeRawTransaction(transactionHex);
+  if (!transaction.status) {
+    return { status: false, error: transaction.error };
+  }
+
+  // Get the transaction inputs
+  const inputs = getTransactionInputs(transaction.transaction!);
+  if (!inputs.status) {
+    return { status: false, error: inputs.error };
+  }
+
+  // Find the indices of inputs that are 2-of-2 multisig
+  const multisigInputIndices: number[] = [];
+
+  for (let i = 0; i < inputs.data!.length; i++) {
+    // Check for 2-of-2 multisig input in legacy format
+    if (inputs.data![i].script.length > 0) {
+      const isLegacy2Of2Multisig = detectLegacy2Of2Multisig(inputs.data![i].script);
+      if (isLegacy2Of2Multisig) {
+        multisigInputIndices.push(i);
+      }
+    }
+    // Check for 2-of-2 multisig input in witness format
+    const isWitness2Of2Multisig = detect2Of2Multisig(inputs.data![i].witness);
+    if (isWitness2Of2Multisig) {
+      multisigInputIndices.push(i);
+    }
+  }
+
+  // Return the result
+  return {
+    status: multisigInputIndices.length > 0,
+    inputs: multisigInputIndices,
+  };
+};
+
+// Function to detect lightning channel close inputs in PSBT format
+export const detectLightningChannelClosePsbt = (psbtBase64:string): DetectLightningChannelCloseResponse=> {
+
+  // Convert PSBT to transaction hex
+  const transactionHex = convertPsbtToHex(psbtBase64);
+  if(transactionHex.status === false) {
+    return { status: false , error: transactionHex.error}
+  }
+
+  // Detect lightning channel close inputs
+  return detectLightningChannelClose(transactionHex.transactionHex!);
+}


### PR DESCRIPTION
Added common functions
- `converPsbtToHex`
Retrieves raw transaction hex from a PSBT
- `decodeRawTransaction`
Decodes Raw transaction Hex to a standard transaction
- `getTransactionInputs`
Retrieves transaction inputs from a transaction

Feature
Detect lightning channel closing transaction inputs 
(only legacy scriptSig are now supported)
 - from a transaction hex `detectLightningChannelClose`
 - from a psbt `detectLightningChannelClosePsbt`


